### PR TITLE
🧹 Refactor: Remove duplicate MD5 hashing logic

### DIFF
--- a/pdfrecon/app_gui.py
+++ b/pdfrecon/app_gui.py
@@ -57,6 +57,7 @@ requests = _import_with_fallback('requests', 'requests', 'requests')
 # --- Import configuration and version ---
 from .config import PDFReconConfig, PDFProcessingError, PDFCorruptionError, \
     PDFTooLargeError, PDFEncryptedError, APP_VERSION, UI_COLORS, UI_FONTS, UI_DIMENSIONS
+from .utils import md5_file
 
 # --- OCG (layers) detection helpers ---
 _LAYER_OCGS_BLOCK_RE = re.compile(rb"/OCGs\s*\[(.*?)\]", re.S)
@@ -112,20 +113,6 @@ class PDFEncryptedError(PDFProcessingError):
     """Exception for encrypted files that cannot be read."""
     pass
 # --- End Phase 1/3 ---
-def md5_file(fp: Path, buf_size: int = 4 * 1024 * 1024) -> str:
-    """
-    Fast MD5 with reusable buffer (fewer allocations).
-    """
-    h = hashlib.md5()
-    with fp.open("rb", buffering=0) as f:
-        buf = bytearray(buf_size)
-        mv = memoryview(buf)
-        while True:
-            n = f.readinto(mv)
-            if not n:
-                break
-            h.update(mv[:n])
-    return h.hexdigest()
 
 
 def fmt_times_pair(ts: float):


### PR DESCRIPTION
🎯 **What:** Removed duplicate `md5_file` function in `pdfrecon/app_gui.py` and imported it from `pdfrecon/utils.py`.
💡 **Why:** To eliminate code duplication and centralize utility functions, improving maintainability.
✅ **Verification:** Verified that `pdfrecon/utils.py` contains the identical function implementation and that `pdfrecon/app_gui.py` is syntactically correct after the change.
✨ **Result:** Cleaner code with a single source of truth for MD5 file hashing.

---
*PR created automatically by Jules for task [6488771508770338524](https://jules.google.com/task/6488771508770338524) started by @Rasmus-Riis*