### PR TITLE
Refactor: Deduplicate utility functions in app_gui.py

### DIFF
--- a/pdfrecon/app_gui.py
+++ b/pdfrecon/app_gui.py
@@ -58,6 +58,9 @@ requests = _import_with_fallback('requests', 'requests', 'requests')
 from .config import PDFReconConfig, PDFProcessingError, PDFCorruptionError, \
     PDFTooLargeError, PDFEncryptedError, APP_VERSION, UI_COLORS, UI_FONTS, UI_DIMENSIONS
 
+# --- Utilities ---
+from .utils import md5_file
+
 # --- OCG (layers) detection helpers ---
 _LAYER_OCGS_BLOCK_RE = re.compile(rb"/OCGs\s*\[(.*?)\]", re.S)
 _OBJ_REF_RE          = re.compile(rb"(\d+)\s+(\d+)\s+R")
@@ -112,35 +115,6 @@ class PDFEncryptedError(PDFProcessingError):
     """Exception for encrypted files that cannot be read."""
     pass
 # --- End Phase 1/3 ---
-def md5_file(fp: Path, buf_size: int = 4 * 1024 * 1024) -> str:
-    """
-    Fast MD5 with reusable buffer (fewer allocations).
-    """
-    h = hashlib.md5()
-    with fp.open("rb", buffering=0) as f:
-        buf = bytearray(buf_size)
-        mv = memoryview(buf)
-        while True:
-            n = f.readinto(mv)
-            if not n:
-                break
-            h.update(mv[:n])
-    return h.hexdigest()
-
-
-def fmt_times_pair(ts: float):
-    """Return ('DD-MM-YYYY HH:MM:SS±ZZZZ', 'YYYY-mm-ddTHH:MM:SSZ')."""
-    local = datetime.fromtimestamp(ts).astimezone()
-    utc = datetime.fromtimestamp(ts, tz=timezone.utc)
-    return local.strftime("%d-%m-%Y %H:%M:%S%z"), utc.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-def safe_stat_times(path: Path):
-    try:
-        st = path.stat()
-        return st.st_ctime, st.st_mtime
-    except Exception:
-        return None, None
-
 
 
 class PDFReconApp:


### PR DESCRIPTION
This PR addresses duplicated code in `pdfrecon/app_gui.py` by removing utility functions that are either unused or already available in `pdfrecon/utils.py`.

Specifically:
- `md5_file`: Removed duplicate definition and imported from `.utils`. This function is identical in both files.
- `fmt_times_pair`: Removed definition as it is unused in `app_gui.py` and globally. It exists in `.utils` if needed.
- `safe_stat_times`: Removed definition as it is unused in `app_gui.py` and globally. Note that the version in `app_gui.py` had a different return signature than the one in `.utils`, but since it was unused, safe removal is preferred over replacement.

Verification:
- Created a script `verify_refactor.py` to confirm `md5_file` is available via import and others are removed.
- Grepped the codebase to ensure no other usages of the removed functions exist.

---
*PR created automatically by Jules for task [7267811221037781506](https://jules.google.com/task/7267811221037781506) started by @Rasmus-Riis*