### PR TITLE
🧹 Remove redundant PDFReconConfig redefinition in app_gui.py

### DIFF
--- a/pdfrecon/app_gui.py
+++ b/pdfrecon/app_gui.py
@@ -86,32 +86,6 @@ def count_layers(pdf_bytes: bytes) -> int:
     return len(refs)
 
 
-# --- PHASE 1/3: Configuration and Custom Exceptions ---
-class PDFReconConfig:
-    """Configuration settings for PDFRecon. Values are loaded from config.ini."""
-    MAX_FILE_SIZE = 1000 * 1024 * 1024  # 500MB
-    MAX_REVISIONS = 100
-    EXIFTOOL_TIMEOUT = 30
-    MAX_WORKER_THREADS = min(16, (os.cpu_count() or 4) * 2)
-    VISUAL_DIFF_PAGE_LIMIT = 15
-    EXPORT_INVALID_XREF = False
-
-class PDFProcessingError(Exception):
-    """Base exception for PDF processing errors."""
-    pass
-
-class PDFCorruptionError(PDFProcessingError):
-    """Exception for corrupt or unreadable PDF files."""
-    pass
-
-class PDFTooLargeError(PDFProcessingError):
-    """Exception for files that exceed the size limit."""
-    pass
-
-class PDFEncryptedError(PDFProcessingError):
-    """Exception for encrypted files that cannot be read."""
-    pass
-# --- End Phase 1/3 ---
 def md5_file(fp: Path, buf_size: int = 4 * 1024 * 1024) -> str:
     """
     Fast MD5 with reusable buffer (fewer allocations).


### PR DESCRIPTION
🎯 **What:** Removed the redefinition of `PDFReconConfig` and related exception classes in `pdfrecon/app_gui.py`.

💡 **Why:** These classes are already defined in `pdfrecon/config.py` and imported into `app_gui.py`. The redefinition was redundant and could lead to inconsistencies (e.g., missing configuration options like `TEXT_EXTRACTION_TIMEOUT`).

✅ **Verification:** Verified that `app_gui.py` now correctly uses the `PDFReconConfig` from `config.py` using a reproduction script. Confirmed that attributes like `TEXT_EXTRACTION_TIMEOUT` are accessible.

✨ **Result:** Improved maintainability and consistency of the codebase.


---
*PR created automatically by Jules for task [16361007616513845666](https://jules.google.com/task/16361007616513845666) started by @Rasmus-Riis*