### PR TITLE
Clean up unnecessary nested imports in app_gui.py

### DIFF
--- a/pdfrecon/app_gui.py
+++ b/pdfrecon/app_gui.py
@@ -3909,7 +3909,6 @@ class PDFReconApp:
         return events        
     def _clean_cell_value(self, value):
         """Fjerner tegn, der kan give XLSX/XML-fejl (BOM/mojibake/kontroltegn)."""
-        import re
         if value is None:
             return ""
         s = str(value)
@@ -5043,7 +5042,6 @@ class PDFReconApp:
                 if not text:
                     continue
                 # Split by any non-alphanumeric and look for word-like patterns
-                import re
                 words = re.findall(r'[A-Za-zÀ-ÿ]{3,}', text)  # Words with 3+ letters including Danish chars
                 searchable_fragments.extend(words)
             


### PR DESCRIPTION
Removed redundant `import re` statements at line 3912 and 5046 in `pdfrecon/app_gui.py`. The `re` module is already imported at the module level. Verified with a reproduction script that `_clean_cell_value` and `_get_touchup_regions_for_page` continue to work correctly.

---
*PR created automatically by Jules for task [16964776271287839093](https://jules.google.com/task/16964776271287839093) started by @Rasmus-Riis*