### PR TITLE
⚡ Optimize PDF revision slicing with memoryview

### DIFF
--- a/pdfrecon/app_gui.py
+++ b/pdfrecon/app_gui.py
@@ -4980,7 +4980,7 @@ class PDFReconApp:
         full_text = []
         doc = None
         try:
-            if isinstance(source, bytes):
+            if isinstance(source, (bytes, bytearray, memoryview)):
                 doc = fitz.open(stream=source, filetype="pdf")
             else:
                 resolved_path = self._resolve_case_path(source) # Resolve the path

--- a/pdfrecon/scanner.py
+++ b/pdfrecon/scanner.py
@@ -73,9 +73,11 @@ def extract_revisions(raw: bytes, original_path: Path):
         # Define subdirectory for potential revisions
         altered_dir = original_path.parent / "Altered_files"
         
+        raw_mv = memoryview(raw)
+
         for i, offset in enumerate(valid_offsets, start=1):
             # The revision is the content from the start to the EOF marker
-            rev_bytes = raw[:offset + 5]
+            rev_bytes = raw_mv[:offset + 5]
             rev_filename = f"{original_path.stem}_rev{i}_@{offset}.pdf"
             rev_path = altered_dir / rev_filename
             revisions.append((rev_path, original_path.name, rev_bytes))


### PR DESCRIPTION
Optimized memory usage in `extract_revisions` by using `memoryview` for slicing. Updated `_get_text_for_comparison` to handle `memoryview` inputs. Validated with benchmarks showing significant performance improvement.

---
*PR created automatically by Jules for task [17051117025079893926](https://jules.google.com/task/17051117025079893926) started by @Rasmus-Riis*