### PR TITLE
🧹 Refactor PDF Validation Logic

### DIFF
--- a/pdfrecon/app_gui.py
+++ b/pdfrecon/app_gui.py
@@ -57,6 +57,7 @@ requests = _import_with_fallback('requests', 'requests', 'requests')
 # --- Import configuration and version ---
 from .config import PDFReconConfig, PDFProcessingError, PDFCorruptionError, \
     PDFTooLargeError, PDFEncryptedError, APP_VERSION, UI_COLORS, UI_FONTS, UI_DIMENSIONS
+from .pdf_processor import validate_pdf_file
 
 # --- OCG (layers) detection helpers ---
 _LAYER_OCGS_BLOCK_RE = re.compile(rb"/OCGs\s*\[(.*?)\]", re.S)
@@ -2900,36 +2901,6 @@ class PDFReconApp:
                 if fn.lower().endswith(".pdf"):
                     yield Path(base) / fn
 
-    def validate_pdf_file(self, filepath):
-        """
-        Validates a PDF file based on size, header, and encryption.
-        Returns True if valid, otherwise raises an appropriate exception.
-        """
-        try:
-            # Check file size
-            if filepath.stat().st_size > PDFReconConfig.MAX_FILE_SIZE:
-                raise PDFTooLargeError(f"File exceeds {PDFReconConfig.MAX_FILE_SIZE // (1024*1024)}MB size limit.")
-
-            # Check PDF header
-            with open(filepath, 'rb') as f:
-                if f.read(5) != b'%PDF-':
-                    raise PDFCorruptionError("Invalid PDF header. Not a PDF file.")
-            
-            # Check for encryption
-            with fitz.open(filepath) as doc:
-                if doc.is_encrypted:
-                    # Try authenticating with an empty password
-                    if not doc.authenticate(""):
-                         raise PDFEncryptedError("File is encrypted and cannot be processed.")
-            
-            return True
-        except PDFProcessingError:
-            # Re-raise our custom exceptions
-            raise
-        except Exception as e:
-            # Wrap other exceptions in our custom error type
-            raise PDFCorruptionError(f"Could not validate file: {e}")
-
     def _process_large_file_streaming(self, filepath):
         """(Placeholder) Processes a large PDF file using streaming to save memory."""
         logging.info(f"Streaming processing is not yet implemented. Processing {filepath.name} normally.")
@@ -4501,7 +4472,7 @@ class PDFReconApp:
         Processes a single PDF file, submitting copy jobs to a dedicated thread pool.
         """
         try:
-            self.validate_pdf_file(fp)
+            validate_pdf_file(fp)
 
             raw = fp.read_bytes()
             logging.info(f"Processing file: {fp.name} ({len(raw) / (1024*1024):.1f}MB)")

--- a/pdfrecon/pdf_processor.py
+++ b/pdfrecon/pdf_processor.py
@@ -138,11 +138,17 @@ def validate_pdf_file(filepath: Path) -> bool:
         try:
             doc = fitz.open(str(filepath))
             if doc.is_encrypted:
-                doc.close()
-                raise PDFEncryptedError("PDF is password-encrypted and cannot be read")
+                # Try authenticating with an empty password
+                if not doc.authenticate(""):
+                    doc.close()
+                    raise PDFEncryptedError("File is encrypted and cannot be processed.")
             doc.close()
-        except fitz.FileError:
+        except fitz.FileDataError:
             raise PDFCorruptionError("File is not a valid PDF")
+        except Exception as e:
+            if isinstance(e, PDFProcessingError):
+                raise
+            raise PDFCorruptionError(f"File is not a valid PDF: {str(e)}")
         
         return True
         


### PR DESCRIPTION
This PR addresses a code health issue by removing duplicated PDF validation logic in `pdfrecon/app_gui.py`. The validation logic is now centralized in `pdfrecon/pdf_processor.py`.

Changes:
- **`pdfrecon/pdf_processor.py`**: 
    - Updated exception handling to catch `fitz.FileDataError` (replacing the non-existent `fitz.FileError`).
    - Enhanced `validate_pdf_file` to attempt authentication with an empty password before raising a `PDFEncryptedError`, matching the behavior of the GUI.
    - Added a generic exception handler to ensure all validation errors are properly wrapped.
- **`pdfrecon/app_gui.py`**: 
    - Imported `validate_pdf_file` from `.pdf_processor`.
    - Removed the local `validate_pdf_file` method.
    - Updated the call site in `_process_single_file` to use the imported function.

Verification:
- Created and ran a verification script (`verify_processor.py`) that tested `validate_pdf_file` against normal, encrypted (user/owner passwords), and invalid PDF files.
- Confirmed that `test_normal.pdf` and `test_encrypted_owner.pdf` are considered valid.
- Confirmed that `test_encrypted_user.pdf` raises `PDFEncryptedError`.
- Confirmed that `test_invalid.pdf` raises `PDFCorruptionError` (due to invalid header) or `PDFCorruptionError` (due to `fitz` error).
- Manually verified imports and logic in `app_gui.py` via code reading and import check script.


---
*PR created automatically by Jules for task [12850938698279241388](https://jules.google.com/task/12850938698279241388) started by @Rasmus-Riis*