### PR TITLE
🔒 Security: Fix Untrusted Path Execution for ExifTool

### DIFF
--- a/pdfrecon/app_gui.py
+++ b/pdfrecon/app_gui.py
@@ -86,32 +86,6 @@ def count_layers(pdf_bytes: bytes) -> int:
     return len(refs)
 
 
-# --- PHASE 1/3: Configuration and Custom Exceptions ---
-class PDFReconConfig:
-    """Configuration settings for PDFRecon. Values are loaded from config.ini."""
-    MAX_FILE_SIZE = 1000 * 1024 * 1024  # 500MB
-    MAX_REVISIONS = 100
-    EXIFTOOL_TIMEOUT = 30
-    MAX_WORKER_THREADS = min(16, (os.cpu_count() or 4) * 2)
-    VISUAL_DIFF_PAGE_LIMIT = 15
-    EXPORT_INVALID_XREF = False
-
-class PDFProcessingError(Exception):
-    """Base exception for PDF processing errors."""
-    pass
-
-class PDFCorruptionError(PDFProcessingError):
-    """Exception for corrupt or unreadable PDF files."""
-    pass
-
-class PDFTooLargeError(PDFProcessingError):
-    """Exception for files that exceed the size limit."""
-    pass
-
-class PDFEncryptedError(PDFProcessingError):
-    """Exception for encrypted files that cannot be read."""
-    pass
-# --- End Phase 1/3 ---
 def md5_file(fp: Path, buf_size: int = 4 * 1024 * 1024) -> str:
     """
     Fast MD5 with reusable buffer (fewer allocations).
@@ -497,6 +471,13 @@ class PDFReconApp:
                 PDFReconConfig.MAX_WORKER_THREADS = settings.getint('MaxWorkerThreads', PDFReconConfig.MAX_WORKER_THREADS)
                 PDFReconConfig.VISUAL_DIFF_PAGE_LIMIT = settings.getint('VisualDiffPageLimit', 5)
                 PDFReconConfig.EXPORT_INVALID_XREF = settings.getboolean('ExportInvalidXREF', False)
+
+                # Load security settings (optional)
+                PDFReconConfig.EXIFTOOL_PATH = settings.get('ExifToolPath', None)
+                if PDFReconConfig.EXIFTOOL_PATH == "": PDFReconConfig.EXIFTOOL_PATH = None
+                PDFReconConfig.EXIFTOOL_HASH = settings.get('ExifToolHash', None)
+                if PDFReconConfig.EXIFTOOL_HASH == "": PDFReconConfig.EXIFTOOL_HASH = None
+
                 self.default_language = settings.get('Language', 'en')
                 self._config_writable = True
                 return
@@ -3578,8 +3559,74 @@ class PDFReconApp:
 
     def exiftool_output(self, path, detailed=False):
         """Runs ExifTool safely with a timeout and improved error handling."""
-        exe_path = self._resolve_path("exiftool.exe", base_is_parent=True)
-        if not exe_path.is_file(): return self._("exif_err_notfound")
+
+        # --- Security Fix: Secure ExifTool Resolution ---
+        exe_path = None
+        is_safe_location = False
+
+        # 1. Check Configured Path
+        if PDFReconConfig.EXIFTOOL_PATH:
+            p = Path(PDFReconConfig.EXIFTOOL_PATH)
+            if p.is_file():
+                exe_path = p
+                is_safe_location = True # User manually configured it
+
+        # 2. Check System Path (if not configured)
+        if not exe_path:
+            system_path = shutil.which("exiftool")
+            if system_path:
+                exe_path = Path(system_path)
+                is_safe_location = True # System paths are generally trusted
+
+        # 3. Check Bundled Path (if frozen/packaged)
+        if not exe_path:
+            bundled_path = self._resolve_path("exiftool.exe", base_is_parent=False)
+            if bundled_path.is_file():
+                exe_path = bundled_path
+                # If frozen, it's in a temp dir controlled by bootloader => Safe
+                if getattr(sys, 'frozen', False):
+                    is_safe_location = True
+                else:
+                    # Running as script: treat as unsafe unless hash matches
+                    is_safe_location = False
+
+        # 4. Check Local Path (External/Portable)
+        if not exe_path:
+            local_path = self._resolve_path("exiftool.exe", base_is_parent=True)
+            if local_path.is_file():
+                exe_path = local_path
+                is_safe_location = False # Definitely unsafe (next to exe)
+
+        # 5. Not Found
+        if not exe_path:
+            return self._("exif_err_notfound")
+
+        # --- Integrity Check ---
+        # Calculate Hash if configured OR if location is unsafe
+        if PDFReconConfig.EXIFTOOL_HASH or not is_safe_location:
+            try:
+                sha256_hash = hashlib.sha256()
+                with open(exe_path, "rb") as f:
+                    for byte_block in iter(lambda: f.read(4096), b""):
+                        sha256_hash.update(byte_block)
+                file_hash = sha256_hash.hexdigest()
+
+                if PDFReconConfig.EXIFTOOL_HASH:
+                    if file_hash.lower() != PDFReconConfig.EXIFTOOL_HASH.lower():
+                         return f"Error: ExifTool hash mismatch. Expected {PDFReconConfig.EXIFTOOL_HASH}, got {file_hash}."
+
+                elif not is_safe_location:
+                     msg = "Security Error: ExifTool found in untrusted location without integrity verification.\n" \
+                           "To fix this, either:\n" \
+                           "1. Install ExifTool to a system path (e.g. PATH),\n" \
+                           "2. Configure 'ExifToolPath' in config.ini to a trusted location, or\n" \
+                           "3. Configure 'ExifToolHash' in config.ini with the SHA256 hash of the local executable."
+                     logging.error(msg)
+                     return msg
+
+            except Exception as e:
+                logging.error(f"Error verifying ExifTool integrity: {e}")
+                return f"Error verifying ExifTool integrity: {e}"
         
         try:
             file_content = path.read_bytes()

--- a/pdfrecon/config.py
+++ b/pdfrecon/config.py
@@ -65,6 +65,10 @@ class PDFReconConfig:
     VISUAL_DIFF_PAGE_LIMIT = 15
     EXPORT_INVALID_XREF = False
     
+    # Security Configuration
+    EXIFTOOL_PATH = None  # Path to ExifTool executable (optional, overrides default search)
+    EXIFTOOL_HASH = None  # SHA256 hash of ExifTool executable (optional, enforces integrity)
+
     # File processing timeouts (from hang prevention improvements)
     TEXT_EXTRACTION_TIMEOUT = 15  # seconds
     FILE_PROCESSING_TIMEOUT = 60  # seconds

--- a/tests/test_exiftool_security.py
+++ b/tests/test_exiftool_security.py
@@ -1,0 +1,155 @@
+import unittest
+from unittest.mock import MagicMock, patch, mock_open
+import sys
+import hashlib
+from pathlib import Path
+
+# Add project root to path (at beginning to ensure we use local package)
+sys.path.insert(0, ".")
+
+# Mock ALL dependencies that might be missing or cause GUI init
+sys.modules["customtkinter"] = MagicMock()
+sys.modules["tkinter"] = MagicMock()
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = MagicMock()
+sys.modules["tkinterdnd2"] = MagicMock()
+sys.modules["PIL"] = MagicMock()
+sys.modules["PIL.Image"] = MagicMock()
+sys.modules["PIL.ImageTk"] = MagicMock()
+sys.modules["fitz"] = MagicMock()
+sys.modules["openpyxl"] = MagicMock()
+sys.modules["openpyxl.styles"] = MagicMock()
+sys.modules["openpyxl.utils"] = MagicMock()
+sys.modules["requests"] = MagicMock()
+
+# Import modules
+try:
+    from pdfrecon.app_gui import PDFReconApp
+    from pdfrecon.config import PDFReconConfig
+except ImportError as e:
+    print(f"ImportError: {e}")
+    sys.exit(1)
+except SystemExit:
+    print("SystemExit caught during import. A dependency might be triggering exit.")
+    sys.exit(1)
+
+class TestExifToolSecurity(unittest.TestCase):
+    def setUp(self):
+        # Create a mock app instance avoiding __init__
+        self.app = PDFReconApp.__new__(PDFReconApp)
+        # Mock _resolve_path
+        self.app._resolve_path = MagicMock()
+        # Mock translation method
+        self.app._ = MagicMock(side_effect=lambda x: x)
+
+        # Reset Config
+        PDFReconConfig.EXIFTOOL_PATH = None
+        PDFReconConfig.EXIFTOOL_HASH = None
+
+    @patch("shutil.which")
+    @patch("pathlib.Path.is_file", autospec=True)
+    @patch("subprocess.run")
+    def test_system_path_allowed(self, mock_run, mock_is_file, mock_which):
+        """Test that ExifTool found in system path is allowed without hash."""
+        # Setup: found in system path
+        mock_which.return_value = "/usr/bin/exiftool"
+
+        # Ensure Path("/usr/bin/exiftool").is_file() returns True
+        def is_file_side_effect(self_obj):
+            return str(self_obj) == "/usr/bin/exiftool"
+
+        mock_is_file.side_effect = is_file_side_effect
+
+        # Setup PDF path arg
+        path_arg = MagicMock()
+        path_arg.read_bytes.return_value = b"pdf_bytes"
+
+        # Run
+        # Note: We must mock open if it's called.
+        # But system path shouldn't trigger open for hashing.
+        with patch("builtins.open", new_callable=mock_open) as m_open:
+            self.app.exiftool_output(path_arg)
+            m_open.assert_not_called()
+
+        # Verify: subprocess.run called
+        mock_run.assert_called()
+
+    @patch("shutil.which")
+    @patch("pathlib.Path.is_file", autospec=True)
+    def test_local_path_blocked_without_hash(self, mock_is_file, mock_which):
+        """Test that ExifTool found locally is BLOCKED if no hash is configured."""
+        mock_which.return_value = None # Not in system path
+
+        local_path = Path("local/exiftool.exe")
+
+        # _resolve_path returns local_path when looking for external file
+        def resolve_side_effect(name, base_is_parent=False):
+            if name == "exiftool.exe" and base_is_parent:
+                return local_path
+            return Path("nowhere")
+        self.app._resolve_path.side_effect = resolve_side_effect
+
+        # is_file returns True for local_path
+        def is_file_side_effect(self_obj):
+            return str(self_obj) == str(local_path)
+        mock_is_file.side_effect = is_file_side_effect
+
+        # Run
+        path_arg = MagicMock()
+        # Mock open to return bytes for hashing (it will be called)
+        with patch("builtins.open", new_callable=mock_open, read_data=b"exe_content") as m_open:
+            result = self.app.exiftool_output(path_arg)
+            m_open.assert_called()
+
+        # Verify blocked
+        self.assertIn("Security Error", result)
+        self.assertIn("untrusted location", result)
+
+    @patch("shutil.which")
+    @patch("pathlib.Path.is_file", autospec=True)
+    @patch("subprocess.run")
+    def test_local_path_allowed_with_hash(self, mock_run, mock_is_file, mock_which):
+        """Test that ExifTool found locally is ALLOWED if hash matches."""
+        mock_which.return_value = None
+        local_path = Path("local/exiftool.exe")
+
+        self.app._resolve_path.side_effect = lambda name, base_is_parent=False: local_path if base_is_parent else Path("nowhere")
+        mock_is_file.side_effect = lambda self_obj: str(self_obj) == str(local_path)
+
+        # Calculate expected hash
+        sha = hashlib.sha256()
+        sha.update(b"valid_bytes")
+        expected_hash = sha.hexdigest()
+
+        PDFReconConfig.EXIFTOOL_HASH = expected_hash
+
+        path_arg = MagicMock()
+        path_arg.read_bytes.return_value = b"pdf_bytes"
+
+        with patch("builtins.open", new_callable=mock_open, read_data=b"valid_bytes"):
+            self.app.exiftool_output(path_arg)
+
+        mock_run.assert_called()
+
+    @patch("shutil.which")
+    @patch("pathlib.Path.is_file", autospec=True)
+    def test_hash_mismatch_blocks(self, mock_is_file, mock_which):
+        """Test that hash mismatch blocks execution."""
+        mock_which.return_value = None
+        local_path = Path("local/exiftool.exe")
+
+        self.app._resolve_path.side_effect = lambda name, base_is_parent=False: local_path if base_is_parent else Path("nowhere")
+        mock_is_file.side_effect = lambda self_obj: str(self_obj) == str(local_path)
+
+        PDFReconConfig.EXIFTOOL_HASH = "correct_hash_value"
+
+        path_arg = MagicMock()
+
+        with patch("builtins.open", new_callable=mock_open, read_data=b"tampered_bytes"):
+            result = self.app.exiftool_output(path_arg)
+
+        self.assertIn("Error: ExifTool hash mismatch", result)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR addresses a security vulnerability where `exiftool.exe` was executed from the application directory without verification. 

Changes:
1.  Modified `pdfrecon/config.py` to add `EXIFTOOL_PATH` and `EXIFTOOL_HASH` configuration options.
2.  Updated `pdfrecon/app_gui.py` to:
    *   Load these new settings from `config.ini`.
    *   Implement `exiftool_output` with secure resolution logic:
        *   Check configured path (Safe).
        *   Check system path (Safe).
        *   Check bundled/local path (Unsafe unless frozen or verified).
    *   Enforce SHA256 hash verification for unsafe paths or if a hash is explicitly configured.
    *   Fail closed with a descriptive security error if verification fails.
3.  Refactored `pdfrecon/app_gui.py` to remove duplicate class definitions (`PDFReconConfig` and Exceptions) that were shadowing the imported versions from `pdfrecon.config`.
4.  Added `tests/test_exiftool_security.py` to test the new security logic with extensive mocking.

---
*PR created automatically by Jules for task [1352385544107444544](https://jules.google.com/task/1352385544107444544) started by @Rasmus-Riis*