### PR TITLE
⚡ Bolt: Remove duplicate code in app_gui.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-05-23 - Duplicate Code in `_scan_worker_parallel`
+
+**Learning:** I discovered that the `_scan_worker_parallel` method is defined twice in `pdfrecon/app_gui.py`. The second definition overrides the first one. This is a clear case of accidental code duplication, likely from a merge or refactoring error.
+
+**Action:** When working on a large file like `pdfrecon/app_gui.py`, always check for duplicate method definitions. I will remove the first (and seemingly less complete/older) definition of `_scan_worker_parallel` to clean up the code and prevent confusion. The second definition seems to be the one intended to be used as it includes timeout handling.

--- a/pdfrecon/app_gui.py
+++ b/pdfrecon/app_gui.py
@@ -2415,51 +2415,6 @@ class PDFReconApp:
             logging.exception(f"Unexpected error processing file {fp.name}")
             return [{"path": fp, "status": "error", "error_type": "processing_error", "error_message": str(e)}]
 
-    def _scan_worker_parallel(self, folder, q):
-        """
-        Worker thread that finds and processes PDF files in parallel.
-        Sends results to the queue for UI updates.
-        """
-        try:
-            q.put(("scan_status", self._("preparing_analysis")))
-            
-            # Find all PDF files
-            pdf_files = list(self._find_pdf_files_generator(folder))
-            if not pdf_files:
-                q.put(("finished", None))
-                return
-            
-            q.put(("progress_mode_determinate", len(pdf_files)))
-            files_processed = 0
-            
-            # Process files in parallel using ThreadPoolExecutor
-            with ThreadPoolExecutor(max_workers=PDFReconConfig.MAX_WORKER_THREADS) as executor:
-                future_to_path = {executor.submit(self._process_single_file, fp): fp for fp in pdf_files}
-                
-                for future in as_completed(future_to_path):
-                    path = future_to_path[future]
-                    files_processed += 1
-                    
-                    try:
-                        results = future.result()
-                        for result_data in results:
-                            q.put(("file_row", result_data))
-                    except Exception as e:
-                        logging.error(f"Unexpected error from thread pool for file {path.name}: {e}")
-                        q.put(("file_row", {"path": path, "status": "error", "error_type": "unknown_error", "error_message": str(e)}))
-                    
-                    # Calculate progress stats
-                    elapsed_time = time.time() - self.scan_start_time
-                    fps = files_processed / elapsed_time if elapsed_time > 0 else 0
-                    eta_seconds = (len(pdf_files) - files_processed) / fps if fps > 0 else 0
-                    q.put(("detailed_progress", {"file": path.name, "fps": fps, "eta": time.strftime('%M:%S', time.gmtime(eta_seconds))}))
-        
-        except Exception as e:
-            logging.error(f"Error in scan worker: {e}")
-            q.put(("error", f"A critical error occurred: {e}"))
-        finally:
-            q.put(("finished", None))
-
     def _process_queue(self):
         """
         Processes messages from the scan queue and updates the UI.


### PR DESCRIPTION
💡 **What:** Removed the first, shadowed definition of `_scan_worker_parallel` from `pdfrecon/app_gui.py`.
🎯 **Why:** The method was defined twice in the same class. The first definition was effectively dead code as it was overridden by the second definition (which contains the correct timeout handling). This cleanup reduces technical debt and prevents potential bugs if a developer were to modify the wrong function.
📊 **Impact:** Reduces file size slightly and eliminates a source of confusion. No functional change as the removed code was not executable.
🔬 **Measurement:** Verified that the file still parses correctly using `py_compile` and that `grep` shows only one definition of the method. Ran unit test discovery to ensure no import errors.

---
*PR created automatically by Jules for task [8729264588389865526](https://jules.google.com/task/8729264588389865526) started by @Rasmus-Riis*