### PR TITLE
⚡ Bolt: Optimize list literal membership checks to set literal in tight loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,9 +3,7 @@
 **Action:** When scanning large texts for multiple case-insensitive patterns, cache the `.lower()` version of the string once. Use fast substring checks (`if "pattern" in text_lower`) as a prerequisite gate before evaluating more complex regexes. Apply this fast-fail pattern whenever porting or adding new indicator detection logic.
 
 ## 2025-02-17 - Optimize Regex Pre-checks and C-level comprehension
-
 **Learning:** Large PDF text buffers are expensive to search with case-insensitive regex or complex capturing groups. Using `in` operator substring checks acts as a fast-fail mechanism that bypasses the regex engine entirely when patterns are absent. Further, replacing `re.finditer` with `re.findall` combined with list/set comprehensions leverages C-level implementations, yielding significant speedups for gathering elements like object definitions (`obj` and `R`).
-
 **Action:** Whenever parsing large text buffers (like raw PDF text streams), identify static substrings that *must* exist for a complex regex to match. Use `if "substring" in txt:` as a guard clause before applying `re.search` or `re.findall`. Default to `re.findall` within comprehensions rather than iterating over `re.finditer` when building collections of matches.
 
 ## 2024-06-25 - Cache lowercased text for fast pre-checks
@@ -19,3 +17,7 @@
 ## 2024-05-18 - Optimized `sha256_file` and added `usedforsecurity=False`
 **Learning:** `hashlib.md5(usedforsecurity=False)` provides a small performance optimization and avoids crashes on FIPS compliant machines. Also `sha256_file` was not using `buffering=0` with `bytearray` and `memoryview`, leading to excessive allocations, fixing it improved speed by 20%. The regex optimization `txt.lower()` cache was already implemented in earlier PR.
 **Action:** Use `usedforsecurity=False` for all md5 hashes unless used for cryptography. Always use `bytearray` and `memoryview` when hashing files in chunks.
+
+## 2026-03-12 - [Optimize `in` operator membership checks]
+**Learning:** Checking for membership `in` against list literals (e.g., `in ["A", "B"]`) results in O(N) execution time because CPython creates a new list object each time. By replacing list literals with set literals (e.g., `in {"A", "B"}`), CPython's peephole optimizer / AST optimizer applies constant folding, converting the set to a `frozenset`. This changes the membership check to O(1) time complexity, leading to faster execution, especially inside tight processing loops like PDF content stream parsing. Additionally, in iterations, tuple unpacking/iteration is slightly faster or equal to list iteration and set iteration is no better, so `for x in (...)` should be preferred over `for x in [...]` or `for x in {...}`.
+**Action:** Always use set literals `in {"A", "B"}` rather than list literals `in ["A", "B"]` when performing constant membership checks, particularly inside high-frequency or critical loops. Use tuple literals for iteration over constants.

--- a/src/app_gui.py
+++ b/src/app_gui.py
@@ -893,7 +893,7 @@ class PDFReconApp:
             self.tree.heading(self.columns[i], text=self._(key), 
                             command=lambda c=self.columns[i]: self._sort_column(c, False))
             width = col_widths.get(self.columns[i], 120)
-            anchor = "center" if self.columns[i] in ["ID", "Revisions"] else "w"
+            anchor = "center" if self.columns[i] in {"ID", "Revisions"} else "w"
             self.tree.column(self.columns[i], anchor=anchor, width=width)
         
         tree_scrollbar = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
@@ -4857,7 +4857,7 @@ class PDFReconApp:
                             op_name = str(operator)
                             
                             # Track TouchUp scope (BDC / BMC)
-                            if op_name in ["BDC", "BMC"]:
+                            if op_name in {"BDC", "BMC"}:
                                 is_touchup = False
                                 tag = ""
                                 if operands and (isinstance(operands[0], pikepdf.Name) or isinstance(operands[0], str)):
@@ -4879,7 +4879,7 @@ class PDFReconApp:
                                 mp_flag = False
                             
                             # Handle Marked Points (MP / DP)
-                            elif op_name in ["MP", "DP"]:
+                            elif op_name in {"MP", "DP"}:
                                 tag = ""
                                 if operands and (isinstance(operands[0], pikepdf.Name) or isinstance(operands[0], str)):
                                     tag = str(operands[0])
@@ -4903,7 +4903,7 @@ class PDFReconApp:
                             # Determine if current operator should be masked
                             is_inside_touchup = touchup_stack[-1] or in_flagged_bt
                             
-                            if not is_inside_touchup and op_name in ["Tj", "TJ", "'", '"']:
+                            if not is_inside_touchup and op_name in {"Tj", "TJ", "'", '"'}:
                                 # Mask non-TouchUp text by replacing it with spaces
                                 if op_name == "TJ":
                                     new_list = []

--- a/src/app_gui_refactored.py
+++ b/src/app_gui_refactored.py
@@ -893,7 +893,7 @@ class PDFReconApp:
             self.tree.heading(self.columns[i], text=_worker_translate(key), 
                             command=lambda c=self.columns[i]: self._sort_column(c, False))
             width = col_widths.get(self.columns[i], 120)
-            anchor = "center" if self.columns[i] in ["ID", "Revisions"] else "w"
+            anchor = "center" if self.columns[i] in {"ID", "Revisions"} else "w"
             self.tree.column(self.columns[i], anchor=anchor, width=width)
         
         tree_scrollbar = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
@@ -4847,7 +4847,7 @@ class PDFReconApp:
                             op_name = str(operator)
                             
                             # Track TouchUp scope (BDC / BMC)
-                            if op_name in ["BDC", "BMC"]:
+                            if op_name in {"BDC", "BMC"}:
                                 is_touchup = False
                                 tag = ""
                                 if operands and (isinstance(operands[0], pikepdf.Name) or isinstance(operands[0], str)):
@@ -4869,7 +4869,7 @@ class PDFReconApp:
                                 mp_flag = False
                             
                             # Handle Marked Points (MP / DP)
-                            elif op_name in ["MP", "DP"]:
+                            elif op_name in {"MP", "DP"}:
                                 tag = ""
                                 if operands and (isinstance(operands[0], pikepdf.Name) or isinstance(operands[0], str)):
                                     tag = str(operands[0])
@@ -4893,7 +4893,7 @@ class PDFReconApp:
                             # Determine if current operator should be masked
                             is_inside_touchup = touchup_stack[-1] or in_flagged_bt
                             
-                            if not is_inside_touchup and op_name in ["Tj", "TJ", "'", '"']:
+                            if not is_inside_touchup and op_name in {"Tj", "TJ", "'", '"'}:
                                 # Mask non-TouchUp text by replacing it with spaces
                                 if op_name == "TJ":
                                     new_list = []

--- a/src/jpeg_forensics.py
+++ b/src/jpeg_forensics.py
@@ -114,7 +114,7 @@ def extract_jpeg_qt_from_bytes(jpeg_bytes: bytes) -> dict:
             warnings.append('WARNING: Very high QT values (extreme compression)')
         
         # Check for common editing software patterns
-        if any(sig in signature for sig in ['181818', '1c1c1c', '282828']):
+        if any(sig in signature for sig in ('181818', '1c1c1c', '282828')):
             if not match:
                 warnings.append('Pattern matches Photoshop-style compression')
         

--- a/src/scan_worker.py
+++ b/src/scan_worker.py
@@ -157,7 +157,7 @@ def _extract_touchup_text(doc):
                     for operands, operator in ops:
                         op_name = str(operator)
 
-                        if op_name in ["BDC", "BMC"]:
+                        if op_name in {"BDC", "BMC"}:
                             is_touchup = False
                             tag = ""
                             if operands and (isinstance(operands[0], pikepdf.Name) or isinstance(operands[0], str)):
@@ -178,7 +178,7 @@ def _extract_touchup_text(doc):
                             in_flagged_bt = False
                             mp_flag = False
 
-                        elif op_name in ["MP", "DP"]:
+                        elif op_name in {"MP", "DP"}:
                             tag = ""
                             if operands and (isinstance(operands[0], pikepdf.Name) or isinstance(operands[0], str)):
                                 tag = str(operands[0])
@@ -201,7 +201,7 @@ def _extract_touchup_text(doc):
 
                         is_inside_touchup = touchup_stack[-1] or in_flagged_bt
 
-                        if not is_inside_touchup and op_name in ["Tj", "TJ", "'", '"']:
+                        if not is_inside_touchup and op_name in {"Tj", "TJ", "'", '"'}:
                             if op_name == "TJ":
                                 new_list = []
                                 for item in operands[0]:

--- a/src/worker_extracted.py
+++ b/src/worker_extracted.py
@@ -502,7 +502,7 @@ def _extract_touchup_text(doc):
                         op_name = str(operator)
                         
                         # Track TouchUp scope (BDC / BMC)
-                        if op_name in ["BDC", "BMC"]:
+                        if op_name in {"BDC", "BMC"}:
                             is_touchup = False
                             tag = ""
                             if operands and (isinstance(operands[0], pikepdf.Name) or isinstance(operands[0], str)):
@@ -524,7 +524,7 @@ def _extract_touchup_text(doc):
                             mp_flag = False
                         
                         # Handle Marked Points (MP / DP)
-                        elif op_name in ["MP", "DP"]:
+                        elif op_name in {"MP", "DP"}:
                             tag = ""
                             if operands and (isinstance(operands[0], pikepdf.Name) or isinstance(operands[0], str)):
                                 tag = str(operands[0])
@@ -548,7 +548,7 @@ def _extract_touchup_text(doc):
                         # Determine if current operator should be masked
                         is_inside_touchup = touchup_stack[-1] or in_flagged_bt
                         
-                        if not is_inside_touchup and op_name in ["Tj", "TJ", "'", '"']:
+                        if not is_inside_touchup and op_name in {"Tj", "TJ", "'", '"'}:
                             # Mask non-TouchUp text by replacing it with spaces
                             if op_name == "TJ":
                                 new_list = []


### PR DESCRIPTION
⚡ Bolt: Optimize list literal membership checks to set literal in tight loops

Replaced instances of list literals `in ["A", "B"]` with set literals `in {"A", "B"}` for membership checks within critical parsing loops (e.g., `_extract_touchup_text`).

💡 What: Changed `op_name in ["BDC", "BMC"]` to `op_name in {"BDC", "BMC"}` and similarly for other membership checks inside loops. Also replaced `for sig in ['181818', ...]` with a tuple `for sig in ('181818', ...)`.
🎯 Why: CPython evaluates list membership tests `in [...]` as O(N) operations, instantiating the list every time. By using `in {...}`, CPython's optimizer applies constant folding to create a `frozenset`, transforming the check to an O(1) hash lookup, resulting in faster execution, especially inside tight content parsing loops. Tuple iteration is used for constants instead of sets because they are generally faster or equal compared to sets.
📊 Impact: Expected to reduce CPU overhead in dense PDF content stream parsing.
🔬 Measurement: Verify changes in `src/scan_worker.py`, `src/app_gui.py`, `src/app_gui_refactored.py`, `src/worker_extracted.py` and `src/jpeg_forensics.py`. Run tests.

---
*PR created automatically by Jules for task [16636641140785749714](https://jules.google.com/task/16636641140785749714) started by @Rasmus-Riis*