### PR TITLE
⚡ Bolt: Replace re.finditer with re.findall for faster regex text extraction

### DIFF
--- a/src/app_gui.py
+++ b/src/app_gui.py
@@ -4243,13 +4243,13 @@ class PDFReconApp:
 
         # Try to find all streams more robustly
         # This regex handles cases with different line endings or extra spaces
-        stream_matches = list(re.finditer(rb"(?s)stream\b(.*?)\bendstream", raw))
+        stream_matches = re.findall(rb"(?s)stream\b(.*?)\bendstream", raw)
         
         # Track if we found any TouchUp forensic markers during decompression
         found_touchup_marker = False
 
-        for m in stream_matches:
-            body = m.group(1).strip(b"\r\n ")
+        for match in stream_matches:
+            body = match.strip(b"\r\n ")
             if len(body) <= 500_000:  # Increased limit for complex content streams
                 try:
                     decompressed = PDFReconApp.decompress_stream(body)

--- a/src/app_gui_refactored.py
+++ b/src/app_gui_refactored.py
@@ -4231,13 +4231,13 @@ class PDFReconApp:
 
         # Try to find all streams more robustly
         # This regex handles cases with different line endings or extra spaces
-        stream_matches = list(re.finditer(rb"(?s)stream\b(.*?)\bendstream", raw))
+        stream_matches = re.findall(rb"(?s)stream\b(.*?)\bendstream", raw)
         
         # Track if we found any TouchUp forensic markers during decompression
         found_touchup_marker = False
 
-        for m in stream_matches:
-            body = m.group(1).strip(b"\r\n ")
+        for match in stream_matches:
+            body = match.strip(b"\r\n ")
             if len(body) <= 500_000:  # Increased limit for complex content streams
                 try:
                     decompressed = PDFReconApp.decompress_stream(body)

--- a/src/scan_worker.py
+++ b/src/scan_worker.py
@@ -80,11 +80,11 @@ def _extract_text_for_scanning(raw: bytes) -> str:
     This is the standalone equivalent of PDFReconApp.extract_text().
     """
     txt_segments = []
-    stream_matches = list(re.finditer(rb"(?s)stream\b(.*?)\bendstream", raw))
+    stream_matches = re.findall(rb"(?s)stream\b(.*?)\bendstream", raw)
 
     found_touchup_marker = False
-    for m in stream_matches:
-        body = m.group(1).strip(b"\r\n ")
+    for match in stream_matches:
+        body = match.strip(b"\r\n ")
         if len(body) <= 500_000:
             try:
                 decompressed = _decompress_stream(body)


### PR DESCRIPTION
⚡ Bolt: Replace `re.finditer` with `re.findall` for faster regex text extraction

**💡 What:** We replaced `list(re.finditer(pattern, raw))` with `re.findall(pattern, raw)` in the text extraction logic for PDF streams (`(?s)stream\b(.*?)\bendstream`). This allows the C-level regex engine to directly return the captured group contents rather than creating intermediate match objects.

**🎯 Why:** `re.finditer` creates full `re.Match` objects for every match found, requiring an additional Python-level iteration to call `.group(1)` to get the actual data. For large files containing thousands of match objects, this is slow. `re.findall` with exactly one capture group returns a flat list of strings natively from the C-engine.

**📊 Impact:** Reduced overhead and faster time extracting text streams from PDF files.

**🔬 Measurement:** Verified functionality by running `pytest tests/` to ensure text extraction still parses perfectly. No visual tests needed.

---
*PR created automatically by Jules for task [1929679106675351662](https://jules.google.com/task/1929679106675351662) started by @Rasmus-Riis*