### PR TITLE
⚡ Bolt: [performance improvement] Replace list literals with set literals in performance-critical loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2024-03-24 - Fast-Fail Substring Pre-Checks for Regex
 **Learning:** For performance optimization on large byte arrays and text blocks (e.g., raw PDF data in `src/advanced_forensics.py`), using literal substring pre-checks (like `b'\x00' * 200 in pdf_bytes` or `"@" in txt`) as a fast-path filter before invoking `re.findall` significantly reduces execution time (50x-200x speedups) by bypassing the regex engine overhead when the pattern is absent.
 **Action:** Always implement literal substring guards for expensive regular expressions applied to large strings or byte sequences when the literal is a required component of the pattern.
+
+## 2024-05-20 - Fast-fail guard checks regression
+**Learning:** When applying 'fast fail' substring checks before expensive regular expressions (e.g., `if "obj" in txt:`), ensure the substring is not overwhelmingly common in the typical happy path. If the guard substring is almost always present, the application will be forced to scan large text strings twice, causing a net performance regression rather than an optimization.
+**Action:** Evaluate the frequency of the substring in the happy path before adding a fast-fail guard check.

--- a/src/advanced_forensics.py
+++ b/src/advanced_forensics.py
@@ -846,7 +846,7 @@ def detect_non_embedded_fonts(doc, indicators: dict):
             if doc.xref_is_font(xref):
                 # Font dictionaries for embedded fonts should contain FontFile, FontFile2, or FontFile3
                 font_dict = doc.xref_object(xref)
-                if not any(f in font_dict for f in ["/FontFile", "/FontFile2", "/FontFile3"]):
+                if not any(f in font_dict for f in {"/FontFile", "/FontFile2", "/FontFile3"}):
                     # Get font name
                     res = doc.xref_get_key(xref, "BaseFont")
                     name = res[1][1:] if res[0] == "name" else f"xref {xref}"

--- a/src/data_processing.py
+++ b/src/data_processing.py
@@ -1239,7 +1239,7 @@ class DataProcessingMixin:
                         for operands, operator in ops:
                             op_name = str(operator)
                             
-                            if op_name in ["BDC", "BMC"]:
+                            if op_name in {"BDC", "BMC"}:
                                 is_touchup = False
                                 tag = ""
                                 if operands and (isinstance(operands[0], pikepdf.Name) or isinstance(operands[0], str)):
@@ -1260,7 +1260,7 @@ class DataProcessingMixin:
                                 in_flagged_bt = False
                                 mp_flag = False
                             
-                            elif op_name in ["MP", "DP"]:
+                            elif op_name in {"MP", "DP"}:
                                 tag = ""
                                 if operands and (isinstance(operands[0], pikepdf.Name) or isinstance(operands[0], str)):
                                     tag = str(operands[0])
@@ -1283,7 +1283,7 @@ class DataProcessingMixin:
                             
                             is_inside_touchup = touchup_stack[-1] or in_flagged_bt
                             
-                            if not is_inside_touchup and op_name in ["Tj", "TJ", "'", '"']:
+                            if not is_inside_touchup and op_name in {"Tj", "TJ", "'", '"'}:
                                 if op_name == "TJ":
                                     new_list = []
                                     for item in operands[0]:


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Replace list literals with set literals in performance-critical loops

* What: Replaced list literals `[...]` with set literals `{...}` inside `src/data_processing.py` and `src/advanced_forensics.py` where they were used with the `in` operator in performance-critical areas.
* Why: In Python, the `in` operator combined with a set literal (`{"A", "B"}`) is compiled into a `frozenset` at bytecode level (constant folding). This makes membership tests O(1) compared to O(n) for list literals (`["A", "B"]`). In hot paths parsing thousands of PDF operators, replacing list literals with set literals reduces CPU overhead during PDF forensics scanning.
* Impact: Reduces CPU overhead during PDF forensics scanning.
* Measurement: Can be measured by profiling the PDF scanning function before and after the change.

---
*PR created automatically by Jules for task [10032789068214755286](https://jules.google.com/task/10032789068214755286) started by @Rasmus-Riis*