### PR TITLE
⚡ Bolt: [performance improvement] Optimize object instantiation in export module

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,7 @@
 ## 2024-04-26 - Native String Ops Over re.sub
 **Learning:** Using `re.sub` for simple string prefix stripping and character filtering introduces significant overhead in hot parsing paths (like UUID cleaning and date normalization). Native string operations (`startswith`/slicing, `.replace()`, and `filter`) are up to 3x-4x faster than their regex equivalents. Furthermore, chained `if` checks are safer than regex for handling stacked prefixes.
 **Action:** Always prefer native string slicing, `.startswith`, or chained `.replace()` over `re.sub` when stripping fixed prefixes or a small set of known characters.
+
+## 2024-05-19 - Pre-mapping and pre-caching object instantiation to prevent O(N^2) and identical instantiation inside loop
+**Learning:** The `export_to_excel` and `_export_to_excel` loops instantiated identically parametered `Alignment(wrap_text=True, vertical="top")` objects inside a loop, resulting in a large memory and garbage collection cost, especially over extensive datasets. Furthermore, repeated uses of `getattr` or `dict.get` lookups inside loops are expensive compared to caching the function object prior to loop execution.
+**Action:** When iterating over a loop to set objects like openpyxl cell styles, if the style object parameters are constant, instantiate the object outside the loop and assign it by reference. When performing a `.get` or `.method` within a loop, cache it in a local variable beforehand.

--- a/src/export_logic.py
+++ b/src/export_logic.py
@@ -207,15 +207,21 @@ class ExportMixin:
             else:
                 indicators_by_path[path_str] = ""
 
+        # ⚡ Bolt Optimization: Cache dict .get methods and Alignment instance before loop
+        get_exif = self.exif_outputs.get
+        get_indicator = indicators_by_path.get
+        get_note = self.file_annotations.get
+        cell_alignment = Alignment(wrap_text=True, vertical="top")
+
         for row_idx, row_data in enumerate(getattr(self, "report_data", []), start=2):
             try:
                 path = row_data[4] 
             except IndexError:
                 path = ""
 
-            exif_text = self.exif_outputs.get(path, "")
-            indicators_full = indicators_by_path.get(path, "")
-            note_text = self.file_annotations.get(path, "")
+            exif_text = get_exif(path, "")
+            indicators_full = get_indicator(path, "")
+            note_text = get_note(path, "")
 
             row_out = list(row_data)
             
@@ -229,7 +235,7 @@ class ExportMixin:
 
             for col_idx, value in enumerate(row_out, start=1):
                 cell = ws.cell(row=row_idx, column=col_idx, value=clean_cell_value(value))
-                cell.alignment = Alignment(wrap_text=True, vertical="top")
+                cell.alignment = cell_alignment
 
         for col in ws.columns:
             try:

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -130,15 +130,21 @@ def export_to_excel(file_path, report_data: list, all_scan_data: dict, file_anno
             else:
                 indicators_by_path[path_str] = ""
 
+        # ⚡ Bolt Optimization: Cache dict .get methods and Alignment instance before loop
+        get_exif = exif_outputs.get
+        get_indicator = indicators_by_path.get
+        get_note = file_annotations.get
+        cell_alignment = Alignment(wrap_text=True, vertical="top")
+
         for row_idx, row_data in enumerate(report_data, start=2):
             try:
                 path = row_data[4]  # Path is at index 4
             except IndexError:
                 path = ""
 
-            exif_text = exif_outputs.get(path, "")
-            indicators_full = indicators_by_path.get(path, "")
-            note_text = file_annotations.get(path, "")
+            exif_text = get_exif(path, "")
+            indicators_full = get_indicator(path, "")
+            note_text = get_note(path, "")
 
             row_out = list(row_data)
             
@@ -152,7 +158,7 @@ def export_to_excel(file_path, report_data: list, all_scan_data: dict, file_anno
 
             for col_idx, value in enumerate(row_out, start=1):
                 cell = ws.cell(row=row_idx, column=col_idx, value=clean_cell_value(value))
-                cell.alignment = Alignment(wrap_text=True, vertical="top")
+                cell.alignment = cell_alignment
 
         for col in ws.columns:
             try:


### PR DESCRIPTION
💡 What: Extracted `Alignment(wrap_text=True, vertical="top")` out of the cell modification loops in Excel export scripts to stop repeatedly instantiating immutable style objects. Additionally cached `.get` methods like `exif_outputs.get` locally to bypass the `LOAD_ATTR` operation overhead.

🎯 Why: Repeatedly instantiating objects and looking up methods during high-frequency loop operations creates unnecessary memory overhead, garbage collection tax, and slows down performance on large report exports.

📊 Impact: Reduces memory load and garbage collection overhead during large PDF scan exports to Excel, decreasing export wait time slightly for users with large cases.

🔬 Measurement: Review memory usage or execution time profile before and after this optimization during a very large scan export. Or visually inspect the diff to confirm that identical constants are moved out of the row iteration loop.

---
*PR created automatically by Jules for task [7304170122167659468](https://jules.google.com/task/7304170122167659468) started by @Rasmus-Riis*