### PR TITLE
⚡ Bolt: Cache method references and object instantiation in Excel export

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,7 @@
 ## 2025-05-19 - Optimize literal keyword counting
 **Learning:** Using `len(re.findall(r"\bkeyword\b", text))` to count occurrences of a literal string is very slow compared to the native Python method `text.count("keyword")`. For a large PDF text extraction loop, checking "endobj" occurrences can be extremely fast (approx. 37x speedup for this operation) by relying on `string.count`, which avoids regex compilation and engine overhead entirely, assuming the keyword does not need complex word boundary matching. Note that in PDFs `endobj` almost universally appears as an isolated token so `\b` is unnecessary.
 **Action:** Always prefer `string.count("word")` over `len(re.findall(r"\bword\b", string))` when checking for the number of occurrences of a unique, known literal keyword, especially inside loops over large text buffers.
+
+## 2025-05-20 - Cache dict references and object creation outside export loops
+**Learning:** In export modules (e.g. `src/export_logic.py` and `src/exporter.py`), repeatedly resolving dictionary `.get` methods and re-instantiating formatting objects like `openpyxl.styles.Alignment` inside nested data and column loops severely limits performance as the report size grows.
+**Action:** When performing row/column-level iteration for exports, explicitly cache frequently accessed method references (e.g., `get_exif = exif_outputs.get`) and layout configurations (e.g., `cell_alignment = Alignment(...)`) in local variables prior to entering the loop to ensure O(1) processing efficiency per iteration.

--- a/src/export_logic.py
+++ b/src/export_logic.py
@@ -207,15 +207,21 @@ class ExportMixin:
             else:
                 indicators_by_path[path_str] = ""
 
+        # ⚡ Bolt Optimization: Cache dict methods and cell alignment to avoid repeated lookups/instantiation
+        get_exif = self.exif_outputs.get
+        get_indicator = indicators_by_path.get
+        get_note = self.file_annotations.get
+        cell_alignment = Alignment(wrap_text=True, vertical="top")
+
         for row_idx, row_data in enumerate(getattr(self, "report_data", []), start=2):
             try:
                 path = row_data[4] 
             except IndexError:
                 path = ""
 
-            exif_text = self.exif_outputs.get(path, "")
-            indicators_full = indicators_by_path.get(path, "")
-            note_text = self.file_annotations.get(path, "")
+            exif_text = get_exif(path, "")
+            indicators_full = get_indicator(path, "")
+            note_text = get_note(path, "")
 
             row_out = list(row_data)
             
@@ -229,7 +235,7 @@ class ExportMixin:
 
             for col_idx, value in enumerate(row_out, start=1):
                 cell = ws.cell(row=row_idx, column=col_idx, value=clean_cell_value(value))
-                cell.alignment = Alignment(wrap_text=True, vertical="top")
+                cell.alignment = cell_alignment
 
         for col in ws.columns:
             try:

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -130,15 +130,21 @@ def export_to_excel(file_path, report_data: list, all_scan_data: dict, file_anno
             else:
                 indicators_by_path[path_str] = ""
 
+        # ⚡ Bolt Optimization: Cache dict methods and cell alignment to avoid repeated lookups/instantiation
+        get_exif = exif_outputs.get
+        get_indicator = indicators_by_path.get
+        get_note = file_annotations.get
+        cell_alignment = Alignment(wrap_text=True, vertical="top")
+
         for row_idx, row_data in enumerate(report_data, start=2):
             try:
                 path = row_data[4]  # Path is at index 4
             except IndexError:
                 path = ""
 
-            exif_text = exif_outputs.get(path, "")
-            indicators_full = indicators_by_path.get(path, "")
-            note_text = file_annotations.get(path, "")
+            exif_text = get_exif(path, "")
+            indicators_full = get_indicator(path, "")
+            note_text = get_note(path, "")
 
             row_out = list(row_data)
             
@@ -152,7 +158,7 @@ def export_to_excel(file_path, report_data: list, all_scan_data: dict, file_anno
 
             for col_idx, value in enumerate(row_out, start=1):
                 cell = ws.cell(row=row_idx, column=col_idx, value=clean_cell_value(value))
-                cell.alignment = Alignment(wrap_text=True, vertical="top")
+                cell.alignment = cell_alignment
 
         for col in ws.columns:
             try:


### PR DESCRIPTION
💡 What: Cached method references for dictionary `.get()` calls and moved `openpyxl.styles.Alignment(wrap_text=True, vertical="top")` instantiation outside the `for row_idx, row_data in enumerate(...)` export loops in `src/export_logic.py` and `src/exporter.py`.

🎯 Why: During Excel export, `_export_to_excel` dynamically builds rows for `openpyxl`. Previously, it created a new `Alignment` object for *every single cell* generated, leading to O(rows * columns) object allocations. Similarly, it performed repeated lookups for `get` methods on `self.exif_outputs`, `indicators_by_path`, and `self.file_annotations`. By hoisting these out of the loops, we avoid unnecessary attribute resolution and object recreation. `openpyxl` style objects are immutable and designed to be shared among cells safely.

📊 Impact: Significantly reduces export duration and memory overhead for large PDFRecon result datasets. Eliminates redundant cell styling object allocations.

🔬 Measurement: Measure export time on a dataset containing 1,000+ scanned files before and after the change; execution time should be visibly reduced, and memory spikes during the final export operation will be smaller. Verified behavior by running `python3 -m unittest tests.test_exporter`.

---
*PR created automatically by Jules for task [17467893643264599990](https://jules.google.com/task/17467893643264599990) started by @Rasmus-Riis*