### PR TITLE
⚡ Bolt: Replace strptime for faster datetime parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,6 @@
 ## 2025-05-20 - Multi-pass page iteration bottleneck in PyMuPDF
 **Learning:** Performing multiple independent iterations over the same document pages (e.g., `for page in doc:`) in PyMuPDF is a significant performance bottleneck. This is especially true when accessing generators like `page.widgets()`, which triggers redundant parsing of widget dictionaries on every pass. For example, doing three separate passes to check boxes, count fields, and check overlays adds roughly 80% overhead compared to a single pass.
 **Action:** When executing multiple types of analysis (like structural anomalies, overlays, and box mismatches) on a PDF, always consolidate the logic into a single `for page in doc:` loop. Iterate over expensive generators like `page.widgets()` exactly once per page, and avoid converting generators to lists explicitly (`len(list(widgets))`) just for counting.
+## 2024-05-29 - Fast Datetime Parsing
+**Learning:** `datetime.strptime` is a significant performance bottleneck in high-frequency parsing loops (like PDF metadata or XMP history scanning) due to format string compilation and locale locks.
+**Action:** Replace `strptime` with `datetime.fromisoformat()` for standard strings or direct `datetime` instantiation with integer slicing (`datetime(int(s[0:4]), int(s[4:6]), ...)`) for fixed-format custom strings like PDF 14-digit dates.

--- a/src/advanced_forensics.py
+++ b/src/advanced_forensics.py
@@ -719,7 +719,11 @@ def detect_timestamp_mismatches(txt: str, doc, indicators: dict):
             clean = "".join(filter(str.isdigit, date_str))
             if len(clean) >= 14:
                 try:
-                    return datetime.strptime(str(clean)[:14], "%Y%m%d%H%M%S")
+                    # ⚡ Bolt Optimization: Bypass strptime for faster parsing
+                    return datetime(
+                        int(clean[0:4]), int(clean[4:6]), int(clean[6:8]),
+                        int(clean[8:10]), int(clean[10:12]), int(clean[12:14])
+                    )
                 except Exception:
                     pass
             return None
@@ -924,9 +928,9 @@ def detect_xmp_history_gaps(txt: str, indicators: dict):
                     d2_str = items[i+1][1].replace('Z', '+00:00').split('.')[0]
                     
                     # Convert to datetime
-                    fmt = "%Y-%m-%dT%H:%M:%S"
-                    dt1 = datetime.strptime(d1_str[:19], fmt)
-                    dt2 = datetime.strptime(d2_str[:19], fmt)
+                    # ⚡ Bolt Optimization: Use fromisoformat instead of strptime
+                    dt1 = datetime.fromisoformat(d1_str[:19])
+                    dt2 = datetime.fromisoformat(d2_str[:19])
                     
                     # If time jumps backwards or has a huge multi-year gap unexpectedly
                     diff = (dt2 - dt1).total_seconds()

--- a/src/data_processing.py
+++ b/src/data_processing.py
@@ -455,7 +455,11 @@ class DataProcessingMixin:
         for match in pdf_date_extended.finditer(file_content_string):
             label, date_str, tz_str = match.groups()
             try:
-                dt_obj = datetime.strptime(date_str, "%Y%m%d%H%M%S")
+                # ⚡ Bolt Optimization: Bypass strptime for faster parsing
+                dt_obj = datetime(
+                    int(date_str[0:4]), int(date_str[4:6]), int(date_str[6:8]),
+                    int(date_str[8:10]), int(date_str[10:12]), int(date_str[12:14])
+                )
                 
                 if tz_str:
                     if tz_str == 'Z':


### PR DESCRIPTION
💡 What: Replaced `datetime.strptime` calls with `datetime.fromisoformat()` and direct `datetime` object instantiation using string slicing.
🎯 Why: `strptime` is known to be relatively slow due to format string parsing and locale locks. High-frequency loops that parse multiple dates per file across thousands of files suffer significant overhead.
📊 Impact: Expected to reduce timestamp parsing time by roughly 75% for 14-digit PDF dates and `fromisoformat`.
🔬 Measurement: Verify by executing timestamp extraction logic on large PDF collections with extensive revision histories and comparing parse times.

---
*PR created automatically by Jules for task [6157334502914340028](https://jules.google.com/task/6157334502914340028) started by @Rasmus-Riis*