### PR TITLE
⚡ Bolt: O(1) optimization for xref duplicate detection

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,6 @@
 ## 2025-05-20 - Multi-pass page iteration bottleneck in PyMuPDF
 **Learning:** Performing multiple independent iterations over the same document pages (e.g., `for page in doc:`) in PyMuPDF is a significant performance bottleneck. This is especially true when accessing generators like `page.widgets()`, which triggers redundant parsing of widget dictionaries on every pass. For example, doing three separate passes to check boxes, count fields, and check overlays adds roughly 80% overhead compared to a single pass.
 **Action:** When executing multiple types of analysis (like structural anomalies, overlays, and box mismatches) on a PDF, always consolidate the logic into a single `for page in doc:` loop. Iterate over expensive generators like `page.widgets()` exactly once per page, and avoid converting generators to lists explicitly (`len(list(widgets))`) just for counting.
+## 2025-06-07 - Use Set for O(1) membership checks inside loops
+**Learning:** When accumulating items and checking for duplicates inside a loop in Python, using an `in` check against a `list` (e.g., `if i in my_list:`) creates an O(N^2) time complexity bottleneck on large datasets.
+**Action:** Always use a `set` (e.g., `my_set = set()`, `my_set.add(i)`) for O(1) membership testing rather than a `list` when checking for duplicates inside loops.

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -692,14 +692,15 @@ def _detect_object_anomalies(txt: str, doc, indicators: dict):
         # Using a raw scan for multiple xref tables that redefine the same objects
         xref_sections = re.findall(r"xref\s*\n0\s+\d+\s*\n(.*?)(?=\btrailer\b|xref|$)", txt, re.DOTALL)
         if len(xref_sections) > 1:
-            all_objects = []
+            # ⚡ Bolt Optimization: Use set() instead of list() to avoid O(N^2) membership checks
+            all_objects = set()
             duplicates = set()
             for section in xref_sections:
                 ids = re.findall(r"^(\d+)\s+\d+\s+[nf]\b", section, re.MULTILINE)
                 for i in ids:
                     if i in all_objects:
                         duplicates.add(i)
-                    all_objects.append(i)
+                    all_objects.add(i)
             if duplicates:
                 indicators['DuplicateObjectIDs'] = {
                     'count': len(duplicates),


### PR DESCRIPTION
💡 What: Replaced a `list` with a `set` for tracking `all_objects` in the XREF duplicate detection loop within `src/scanner.py`.
🎯 Why: Using an `in` check against a list inside a loop creates an O(N^2) performance bottleneck when processing PDFs with many objects (e.g., thousands of XREF entries). 
📊 Impact: Transforms membership testing from O(N) to O(1), improving overall loop efficiency from O(N^2) to O(N).
🔬 Measurement: Verified via unit test simulating duplicate objects across XREF streams, and added journal entry in `.jules/bolt.md` documenting this performance anti-pattern.

---
*PR created automatically by Jules for task [10601421359184706750](https://jules.google.com/task/10601421359184706750) started by @Rasmus-Riis*