### PR TITLE
⚡ Bolt: Prevent O(N^2) tag lookups during export

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -323,22 +323,29 @@ def export_to_html(file_path, report_data: list, file_annotations: dict, all_sca
         
         rows = ""
         
+        # Pre-compute path-to-tag mapping to avoid O(N^2) lookups
+        path_to_tag_class = {}
+        if tree_get_children and tree_item:
+            for item_id in tree_get_children():
+                try:
+                    item_values = tree_item(item_id, "values")
+                    if len(item_values) > 4:
+                        path_val = item_values[4]
+                        tags = tree_item(item_id, "tags")
+                        if tags:
+                            path_to_tag_class[path_val] = tag_map.get(tags[0], "")
+                except (IndexError, TypeError):
+                    pass
+
         # Generate Table Rows
         for i, values in enumerate(report_data):
             tag_class = ""
             try:
-                # Try to get tag from tree if functions provided
-                if tree_get_children and tree_item:
-                    matching_id = next((item_id for item_id in tree_get_children() 
-                                      if tree_item(item_id, "values")[4] == values[4]), None)
-                    if matching_id:
-                        tags = tree_item(matching_id, "tags")
-                        if tags:
-                            tag_class = tag_map.get(tags[0], "")
-            except (IndexError, StopIteration, TypeError):
-                pass
+                path_str = values[4]
+                tag_class = path_to_tag_class.get(path_str, "")
+            except IndexError:
+                path_str = ""
             
-            path_str = values[4]
             note_text = html_escape_module.escape(file_annotations.get(path_str, "")).replace('\n', '<br>')
             
             row_values = [html_escape_module.escape(str(v)) for v in values]


### PR DESCRIPTION
💡 What:
Replaced the O(N^2) inline loop logic in `exporter.py` with an O(N) pre-computed hash map lookup. The code previously searched the Tkinter `Treeview` items iteratively for each row in the report data to find matching tags. It now builds a `path_to_tag_class` dictionary once before entering the export loop, and performs an O(1) dictionary lookup per report row.

🎯 Why:
To prevent massive lag and performance bottlenecks when generating reports (HTML, JSON, etc.) for cases with hundreds or thousands of files. The previous implementation called `tree_item(item_id, "values")` and `tree_get_children()` repeatedly inside an inner loop, accumulating unnecessary overhead from both C-level bridge calls and standard algorithmic complexity.

📊 Impact:
Turns an O(N * M) lookup (where N is report rows and M is tree items) into an O(N + M) operation.

🔬 Measurement:
Run `pnpm test -k test_exporter` (or equivalent test commands) to ensure exports generate valid data with matching tags as before, and notice significant speedups when exporting larger datasets.

---
*PR created automatically by Jules for task [17629340108103605539](https://jules.google.com/task/17629340108103605539) started by @Rasmus-Riis*