### PR TITLE
⚡ Bolt: Optimize HTML export tree lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,6 @@
 ## 2025-05-20 - Multi-pass page iteration bottleneck in PyMuPDF
 **Learning:** Performing multiple independent iterations over the same document pages (e.g., `for page in doc:`) in PyMuPDF is a significant performance bottleneck. This is especially true when accessing generators like `page.widgets()`, which triggers redundant parsing of widget dictionaries on every pass. For example, doing three separate passes to check boxes, count fields, and check overlays adds roughly 80% overhead compared to a single pass.
 **Action:** When executing multiple types of analysis (like structural anomalies, overlays, and box mismatches) on a PDF, always consolidate the logic into a single `for page in doc:` loop. Iterate over expensive generators like `page.widgets()` exactly once per page, and avoid converting generators to lists explicitly (`len(list(widgets))`) just for counting.
+## 2024-05-19 - [Tkinter Treeview Lookup Bottleneck]
+**Learning:** Iterating over `tree_item(item_id, "values")` in `export_to_html` to find tags for each report row incurs an O(N^2) complexity with severe Python-to-Tkinter C-level bridge overhead.
+**Action:** Always pre-compute a UI tree element to data mapping into a native Python dictionary outside of export loops to achieve O(1) lookups and prevent GUI freeze during large data processing.

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -321,24 +321,33 @@ def export_to_html(file_path, report_data: list, file_annotations: dict, all_sca
         if not tag_map:
             tag_map = {"red_row": "red-row", "yellow_row": "yellow-row", "blue_row": "blue-row", "gray_row": "gray-row"}
         
+        # ⚡ Bolt Optimization: Pre-compute path-to-tag mapping to avoid O(N^2) lookups and Tkinter bridge overhead
+        path_to_tag_class = {}
+        if tree_get_children and tree_item:
+            try:
+                for item_id in tree_get_children():
+                    try:
+                        item_values = tree_item(item_id, "values")
+                        if len(item_values) > 4:
+                            path_val = item_values[4]
+                            tags = tree_item(item_id, "tags")
+                            if tags:
+                                path_to_tag_class[path_val] = tag_map.get(tags[0], "")
+                    except (IndexError, TypeError):
+                        pass
+            except TypeError:
+                pass
+
         rows = ""
         
         # Generate Table Rows
         for i, values in enumerate(report_data):
             tag_class = ""
             try:
-                # Try to get tag from tree if functions provided
-                if tree_get_children and tree_item:
-                    matching_id = next((item_id for item_id in tree_get_children() 
-                                      if tree_item(item_id, "values")[4] == values[4]), None)
-                    if matching_id:
-                        tags = tree_item(matching_id, "tags")
-                        if tags:
-                            tag_class = tag_map.get(tags[0], "")
-            except (IndexError, StopIteration, TypeError):
-                pass
-            
-            path_str = values[4]
+                path_str = values[4]
+                tag_class = path_to_tag_class.get(path_str, "")
+            except IndexError:
+                path_str = ""
             note_text = html_escape_module.escape(file_annotations.get(path_str, "")).replace('\n', '<br>')
             
             row_values = [html_escape_module.escape(str(v)) for v in values]


### PR DESCRIPTION
💡 What: Refactored the $O(N^2)$ loop lookup in `export_to_html` (in `src/exporter.py`) into an $O(1)$ pre-computed dictionary mapping.
🎯 Why: Iterating over Tkinter tree items inside the row export loop causes significant execution overhead due to cross-language bridge lag, freezing the main thread for large reports.
📊 Impact: Transforms HTML export performance from $O(N^2)$ to $O(N)$ and effectively eliminates GUI freezing.
🔬 Measurement: Verify by running tests (`PYTHONPATH=. pytest tests/test_exporter.py`) and observing the export speed for datasets containing hundreds of items.

---
*PR created automatically by Jules for task [14167878030958003548](https://jules.google.com/task/14167878030958003548) started by @Rasmus-Riis*